### PR TITLE
Default None for dt0

### DIFF
--- a/src/diffraxtra/_src/diffeq_abc.py
+++ b/src/diffraxtra/_src/diffeq_abc.py
@@ -265,8 +265,8 @@ def from_(
 @AbstractDiffEqSolver.from_.dispatch  # type: ignore[no-redef]
 def from_(
     cls: type[AbstractDiffEqSolver],
-    obj: eqx.Partial,
-    /,  # type: ignore[type-arg]
+    obj: eqx.Partial,  # type: ignore[type-arg]
+    /,
 ) -> AbstractDiffEqSolver:
     """Construct a `DiffEqSolver` from an `equinox.Partial`.
 


### PR DESCRIPTION
This is the counterpart to GalacticDynamics/galax#754 -- I think these are required to support using a constant step size in  `galax.dynamics.experimental.integrate_orbit`.